### PR TITLE
Eliminate the usage of onChanges lifecycle hook by setting tableColumns as signal.

### DIFF
--- a/src/app/components/rule/rule.component.html
+++ b/src/app/components/rule/rule.component.html
@@ -10,7 +10,7 @@
   </button>
 </div>
 
-<app-data-table [tableColumns]="tableColumns" [tableData]="data()" />
+<app-data-table [tableColumns]="tableColumns()" [tableData]="data()" />
 }
 
 <!-- Define the columns of the table -->

--- a/src/app/components/rule/rule.component.ts
+++ b/src/app/components/rule/rule.component.ts
@@ -6,6 +6,7 @@ import {
   inject,
   input,
   OnInit,
+  signal,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -40,7 +41,7 @@ export class RuleComponent implements OnInit {
   data = computed(() =>
     this.ruleService.getDataByRulesEngineId(this.rulesEngineId())
   );
-  tableColumns!: Column[];
+  tableColumns = signal<Column[]>([]);
 
   readonly rulesEngine = computed(() =>
     this.rulesEngineService.getDataByRulesEngineId(this.rulesEngineId())
@@ -55,7 +56,7 @@ export class RuleComponent implements OnInit {
   destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
-    this.tableColumns = [
+    this.tableColumns.set([
       {
         value: 'name',
         name: 'Type Name',
@@ -73,7 +74,7 @@ export class RuleComponent implements OnInit {
         name: 'Actions',
         template: this.actionsTemplate,
       },
-    ];
+    ]);
 
     this.subscription = this.rulesEngineService
       .getCountryName(this.rulesEngineId())

--- a/src/app/components/rules-engine/rules-engine.component.html
+++ b/src/app/components/rules-engine/rules-engine.component.html
@@ -1,6 +1,6 @@
 <h2>{{ headingText }}</h2>
 
-<app-data-table [tableColumns]="tableColumns" [tableData]="data" />
+<app-data-table [tableColumns]="tableColumns()" [tableData]="data" />
 
 <!-- Define the columns of the table -->
 <ng-template #countryIconTemplate let-countryCode>

--- a/src/app/components/rules-engine/rules-engine.component.ts
+++ b/src/app/components/rules-engine/rules-engine.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   inject,
   OnInit,
+  signal,
   TemplateRef,
   ViewChild,
   ViewEncapsulation,
@@ -48,11 +49,11 @@ export class RulesEngineComponent implements OnInit {
  rulesEngineService = inject(RulesEngineService);
  changeDetectionReference = inject(ChangeDetectorRef);
  data = this.rulesEngineService.getData();
- tableColumns: Column[] = [];
+ tableColumns = signal<Column[]>([]);
  readonly headingText = 'Rules Engine';
 
   ngOnInit() {
-    this.tableColumns = [
+    this.tableColumns.set([
       {
         value: 'name',
         name: 'Rule name',
@@ -76,6 +77,6 @@ export class RulesEngineComponent implements OnInit {
         name: 'Actions',
         template: this.actionsTemplate,
       },
-    ];
+    ]);
   }
 }

--- a/src/app/shared/data-table/data-table.component.html
+++ b/src/app/shared/data-table/data-table.component.html
@@ -30,8 +30,8 @@
   </ng-container>
   }
 
-  <tr mat-header-row *matHeaderRowDef="selectedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: selectedColumns"></tr>
+  <tr mat-header-row *matHeaderRowDef="selectedColumns()"></tr>
+  <tr mat-row *matRowDef="let row; columns: selectedColumns()"></tr>
 </table>
 
 <mat-paginator

--- a/src/app/shared/data-table/data-table.component.ts
+++ b/src/app/shared/data-table/data-table.component.ts
@@ -1,11 +1,13 @@
 import {
   AfterViewInit,
   Component,
+  computed,
   DestroyRef,
   inject,
   input,
   OnChanges,
   OnInit,
+  Signal,
   SimpleChanges,
   TrackByFunction,
   ViewChild,
@@ -37,14 +39,14 @@ import { MatInputModule } from '@angular/material/input';
   styleUrl: './data-table.component.css',
 })
 export class DataTableComponent<T extends { id: number }>
-  implements AfterViewInit, OnInit, OnChanges
+  implements AfterViewInit, OnInit
 {
   tableData = input.required<T[]>();
   tableColumns = input.required<Column[]>();
   @ViewChild(MatPaginator) paginator?: MatPaginator;
   identity: TrackByFunction<T> = (_, item: T) => item.id;
 
-  selectedColumns: string[] = [];
+  selectedColumns = computed(() => this.tableColumns().map((c) => c.value));
   dataSource = new MatTableDataSource<T>([]);
 
   subscription?: Subscription;
@@ -57,15 +59,6 @@ export class DataTableComponent<T extends { id: number }>
   ngAfterViewInit() {
     if (this.paginator) {
       this.dataSource.paginator = this.paginator;
-    }
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['tableColumns'] && this.tableColumns) {
-      this.selectedColumns = this.tableColumns().map((c) => c.value);
-    }
-    if (changes['tableData'] && this.tableData) {
-      this.dataSource.data = this.tableData();
     }
   }
 }


### PR DESCRIPTION
Make the code leaner by eliminating onChanges hook usage.